### PR TITLE
fix: recognize Error Status responses in api route handler

### DIFF
--- a/packages/hydrogen/src/utilities/apiRoutes.ts
+++ b/packages/hydrogen/src/utilities/apiRoutes.ts
@@ -2,7 +2,7 @@ import {ImportGlobEagerOutput} from '../types';
 import {matchPath} from './matchPath';
 import {Logger, logServerResponse} from '../utilities/log/log';
 import {ServerComponentRequest} from '../framework/Hydration/ServerComponentRequest.server';
-import { RestError, TeapotError } from './apiStatusResponses';
+import {RestError} from './apiStatusResponses';
 
 let memoizedRoutes: Array<HydrogenApiRoute> = [];
 let memoizedPages: ImportGlobEagerOutput = {};
@@ -128,18 +128,16 @@ export async function renderApiRoute(
         });
       }
     }
-
   } catch (error) {
-    log.error(error);
-
-    console.log('api error instanceof Error: ' + (error instanceof Error))
-    console.log('api error instanceof RestError: ' + (error instanceof RestError))
-    console.log('api error instanceof TeapotError: ' + (error instanceof TeapotError))
-
-    if (error instanceof RestError) {
-      response = (error as RestError).getResponse()
+    // Cannot use error typeof RestError because there
+    // are multiple instances of RestError in memory between
+    // what is imported by `handle-event.ts` and `entry-server.jsx`
+    if (RestError.isRestError(error)) {
+      response = (error as RestError).getResponse();
     } else {
-      response = new Response('Error processing: ' + request.url, {status: 500});
+      response = new Response('Error processing: ' + request.url, {
+        status: 500,
+      });
     }
   }
 

--- a/packages/hydrogen/src/utilities/apiStatusResponses.ts
+++ b/packages/hydrogen/src/utilities/apiStatusResponses.ts
@@ -1,59 +1,43 @@
+const TYPE = '__REST_ERROR__';
 export class RestError extends Error {
-    status: number;
-    details: string;
+  /**
+   *  Cannot use typeof
+   */
+  static isRestError(error: unknown) {
+    if (!error) return false;
+    return (error as RestError).__type === TYPE;
+  }
 
-    constructor(message: string, status: number, details: string) {
-        super(message);
-        this.name = this.constructor.name;
-        this.status = status;
-        this.details = details;
+  __type = TYPE;
+  status: number;
+  details: string;
 
-        // Set the prototype explicitly.
-        Object.setPrototypeOf(this, RestError.prototype)
-    };
+  constructor(message: string, status: number, details: string) {
+    super(message);
+    this.name = this.constructor.name;
+    this.status = status;
+    this.details = details;
+  }
 
-    getResponse() {
-        return new Response(this.message, { status: this.status });
-    };
-
-    getStatus() {
-        return this.status;
-    };
-
-    getDetails() {
-        return this.details;
-    };
-
-    getMessage() {
-        return this.message;
-    };
-};
+  getResponse() {
+    return new Response(this.message, {status: this.status});
+  }
+}
 
 export class BadRequestError extends RestError {
-    constructor(message: string, details: string) {
-        super(message, 400, details);
-
-        // Set the prototype explicitly.
-        Object.setPrototypeOf(this, BadRequestError.prototype)
-    };
-};
+  constructor(message: string, details: string) {
+    super(message, 400, details);
+  }
+}
 
 export class UnauthorizedError extends RestError {
-    constructor(message: string, details: string) {
-        super(message, 401, details);
-
-        // Set the prototype explicitly.
-        Object.setPrototypeOf(this, UnauthorizedError.prototype)
-    };
-};
-
+  constructor(message: string, details: string) {
+    super(message, 401, details);
+  }
+}
 
 export class TeapotError extends RestError {
-    constructor(message: string, details: string) {
-        super(message, 418, details);
-
-        // Set the prototype explicitly.
-        Object.setPrototypeOf(this, TeapotError.prototype)
-    };
-};
-
+  constructor(message: string, details: string) {
+    super(message, 418, details);
+  }
+}

--- a/packages/hydrogen/src/utilities/index.ts
+++ b/packages/hydrogen/src/utilities/index.ts
@@ -21,4 +21,3 @@ export {getMeasurementAsParts, getMeasurementAsString} from './measurement';
 export {parseMetafieldValue} from './parseMetafieldValue';
 export {fetchBuilder, graphqlRequestBody, decodeShopifyId} from './fetch';
 export {getTime} from './timing';
-export * from './apiStatusResponses';

--- a/packages/playground/server-components/src/pages/status/[handle].server.jsx
+++ b/packages/playground/server-components/src/pages/status/[handle].server.jsx
@@ -1,17 +1,13 @@
-import { TeapotError, RestError } from '@shopify/hydrogen/client'
+import {TeapotError, BadRequestError} from '@shopify/hydrogen';
 
 export async function api(request, {params: {handle}}) {
   switch (handle) {
-    case '418': {
-      const error = new TeapotError('I\'m a teapot!', 'The requested entity body is short and stout. ' +
-          'Tip me over and pour me out.')
-
-      console.log('api error instanceof Error: ' + (error instanceof Error))
-      console.log('api error instanceof RestError: ' + (error instanceof RestError))
-      console.log('api error instanceof TeapotError: ' + (error instanceof TeapotError))
-
-      throw error
-    }
+    case '418':
+      throw new TeapotError(
+        "I'm a teapot!",
+        'The requested entity body is short and stout. Tip me over and pour me out.'
+      );
+    case '400':
+      throw new BadRequestError('Bad request', 'This was bad');
   }
-
 }


### PR DESCRIPTION
Cannot use error typeof RestError because there. are multiple instances of RestError in memory between
what is imported by `handle-event.ts` and `entry-server.jsx`.